### PR TITLE
Added info block for maven installation instructions

### DIFF
--- a/java-tooling/index.adoc
+++ b/java-tooling/index.adoc
@@ -114,7 +114,16 @@ A build system allows users to declare and configure individual elements of a bu
 [[build.maven]]
 ### Maven
 
-Maven is currently the predominant tool to build Java based software projects. It's centered around the notion of a Project Object Model (POM) to describe the project, its dependencies and which steps shall be executed during the build.
+https://maven.apache.org[Maven] is currently the predominant tool to build Java based software projects. It's centered around the notion of a Project Object Model (POM) to describe the project, its dependencies and which steps shall be executed during the build.
+
+[NOTE]
+====
+You can install maven by either
+
+* downloading it from the official https://maven.apache.org/download.cgi[website]
+* with https://brew.sh[homebrew] if you're using Mac OSX. Simply run `brew install maven` on the command line
+* or you favorite linux package manager (search for `maven`)
+====
 
 The build execution is backed by a so called https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html[lifecycle] which is basically a predefined set of steps to be executed sequentially. Depending on the type of project that's being built a set of default plugins is assigned to the individual steps. Here's an incomplete list of the most important lifecycle phases:
 
@@ -172,7 +181,7 @@ $
 ----
 ====
 
-If you'd like to see the build in action for a real-world project that produces a bit more output, you can try this (requires Git and Maven installed on your machine).
+If you'd like to see the build in action for a real-world project that produces a bit more output, you can try this (requires https://git-scm.com[Git] and Maven installed on your machine).
 
 [source, bash]
 ----

--- a/java-tooling/index.adoc
+++ b/java-tooling/index.adoc
@@ -35,6 +35,15 @@ NOTE: Sections marked with this icon icon:lightbulb-o[] will define tasks that y
 * https://eclipse.org/downloads/[Eclipse] / https://spring.io/tools/sts[STS] - Adds Spring Framework specific tooling
 * http://maven.apache.org/download.cgi[Maven] (optional) -> to execute the build at the command line (for continuous integration, release builds)
 
+[NOTE]
+====
+You can install maven by either
+
+* downloading it from the official https://maven.apache.org/download.cgi[website]
+* with https://brew.sh[homebrew] if you're using Mac OSX. Simply run `brew install maven` on the command line
+* or you favorite linux package manager (search for `maven`)
+====
+
 [[quick-start]]
 ## Quick start
 
@@ -115,15 +124,6 @@ A build system allows users to declare and configure individual elements of a bu
 ### Maven
 
 https://maven.apache.org[Maven] is currently the predominant tool to build Java based software projects. It's centered around the notion of a Project Object Model (POM) to describe the project, its dependencies and which steps shall be executed during the build.
-
-[NOTE]
-====
-You can install maven by either
-
-* downloading it from the official https://maven.apache.org/download.cgi[website]
-* with https://brew.sh[homebrew] if you're using Mac OSX. Simply run `brew install maven` on the command line
-* or you favorite linux package manager (search for `maven`)
-====
 
 The build execution is backed by a so called https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html[lifecycle] which is basically a predefined set of steps to be executed sequentially. Depending on the type of project that's being built a set of default plugins is assigned to the individual steps. Here's an incomplete list of the most important lifecycle phases:
 


### PR DESCRIPTION
One of the examples says it requires maven to run. I thought it might be good if there are some basic installation instructions present ahead of the example.

I also added a link for Git since perhaps maybe someone potentially hasn't heard of it yet ...

And another link to the maven page, because I think this might be one of the places where people might be interested in more information/a link to the website.

And apparently my editor also changed some whitespace, apologies.
