### PR TITLE
Add not which folder of the Maven project needs to be imported into IDE

### DIFF
--- a/java-tooling/index.adoc
+++ b/java-tooling/index.adoc
@@ -231,7 +231,7 @@ For the sample project we created above the `pom.xml` could look something like 
 
 TIP: Open up the `pom.xml` you've created during the quick start, switch to the XML view and trigger code completion using kbd:[⌃+Space] to get a feel of the completion support the IDE provides.
 
-IDEs support Maven out of the box and usually derive all necessary project settings from the POM. Thus changing something about the project is usually all about tweaking the POM and the refreshing the project setup using kbd:[⌥+F5] (or right-click, menu:Maven[Update Project…]).
+IDEs support Maven out of the boxfootnote:[So long as the pom.xml file is in the projects root directory (topmost/outermost directory)] and usually derive all necessary project settings from the POM. Thus changing something about the project is usually all about tweaking the POM and the refreshing the project setup using kbd:[⌥+F5] (or right-click, menu:Maven[Update Project…]).
 
 TIP: Remove the compiler plugin declaration from the `pom.xml` and refresh the project. See how the JRE System Library node changes back to Java 1.5 (Maven's default). Re-add the plugin declaration, update again and see how it changes back to 1.8 due to our definition of source and target level.
 


### PR DESCRIPTION
I am actually not sure this is a necessary requirement, but I seem to remember that IDEs need the pom.xml to be in the root directory to load it?

If not, disregard this PR.

If it does: I am not sure a footnote is the right way to go here, but I couldn't think of a better solution. Feel free to suggest a different place to put this.
